### PR TITLE
RFC: Marketing & Content – questions, process etc.

### DIFF
--- a/requests-for-comments/marketing-and-content-team.md
+++ b/requests-for-comments/marketing-and-content-team.md
@@ -1,0 +1,50 @@
+# RFC: Marketing & Content Team Questions
+
+As per [my PR on the handbook](https://github.com/PostHog/posthog.com/pull/6010) the Marketing team is potentially evolving to take greater ownership of all content, specifically working with Website & Docs to ensure the docs are up-to-date and maintained to a high-standard.
+
+This poses a bunch of questions about the team, who does what, and how we balance this work against existing marketing work. Here are some questions and answers in no particular order (please add your own):
+
+## Is this a desirable change?
+
+The argument in favor is we have the expertise and process in the content team already. Ian and Lior are both technically knowledgable and excellent writers, and I have opinions about en dashes 😅. 
+
+Another strong argument in favor is that the quality of the docs, and the ease with which users can find answers, is a strong driver of word-of-mouth growth. Given we have the skills and knowledge to contribute, doing so actively supports marketing team objectives.
+
+The risk is combining the two content flows means one or the other suffers, or forces people to spend more time on content they perhaps don't enjoy writing.
+
+For me, I'd imagine an 90/10 - split – i.e. 90% of time spent on existing markeitng content work, 10% on improving docs – but this might be more like 60/40 or 70/30 etc. for other members of the team, and wouldn't be a constant.
+
+## How should / should we divide docs responsibilities?
+
+One option would be to divide docs up among the team – e.g. Ian owns feature flags, Lior owns session replay and so on.
+
+I'd argue against this because:
+
+1. Right now, we probably don't have enough people to divide docs up this way. 
+2. It would lead us to prioritize breadth over impact.
+3. Docs should be owned collectively (e.g. engineering teams should also contribute)
+
+Instead, I think it's best we collectively focus on identifying gaps / priority areas of the docs to improve using data (e.g. most popular / low quality search results), qualatative feedback, and our intuition to guide us.
+
+## How should the approval process work?
+
+We should aim to keep this low process, so we should continue our current habits / process: To me this means:
+
+- Small changes should only require on person's review, or none for trivial fixes (i.e. typos, broken URLs, basic readability stuff etc.)
+
+- New blogs/docs etc. should be reviewed by at least two people.
+
+- Most docs changes / updates shouldn't need Cory's review, but new pages / major updates should. 
+
+- We use our judgment and don't tag Cory on everything because he's busy. Feel free to chip in with your preference here Cory!
+
+## Tutorials vs Docs vs Questions etc.
+
+In the past, we've sometimes ended up writing tutorials for things that should arguably be in the docs. For example:
+
+- [How to set up cross domain tracking in PostHog](https://posthog.com/tutorials/cross-domain-tracking)
+- [How to capture fewer unwanted events](https://posthog.com/tutorials/fewer-unwanted-events)
+
+I don't really have a strong take here, other than to say we can more freely make calls about when something should be a docs page and when it should be a tutorial. We should probably review some tutorials and decide if any should be moved / adapted into docs in future.
+
+I do have a stronger opinion on how we shoud actively use Questions (see this [Slack thread](https://posthog.slack.com/archives/C01V9AT7DK4/p1684415385439629)), but I'll make a separate issue about that as it requires a bit more explanation.


### PR DESCRIPTION
As per [my PR on the handbook](https://github.com/PostHog/posthog.com/pull/6010), the Marketing team is evolving to take greater ownership of all content, specifically working with Website & Docs to ensure the docs are up-to-date and maintained to a high-standard.

This RFC is to discuss implications, how we'll make this work as a team, and how the content team and website team work together.