### PR TITLE
RFC: Base 3000 & Notebooks launch plan

### DIFF
--- a/requests-for-comments/2023-10-27-base3000-launch.md
+++ b/requests-for-comments/2023-10-27-base3000-launch.md
@@ -1,0 +1,34 @@
+# Base 3000 & Notebooks launch
+
+We want to launch the ‘first version’ of PostHog 3000 after the next sprint, which means the week starting November 13th (+ 1 week if needed). We have decided to **include Notebooks** in this launch, so that we can have a big launch that combines functionality and design changes.
+
+## Scope for launch
+
+- Dark Mode
+- Base 3000 [Check this mega issue for details](https://github.com/PostHog/posthog/issues/18089)
+    
+<img width="674" alt="Screenshot 2023-10-27 at 10 38 50" src="https://github.com/PostHog/meta/assets/14750837/abb9e559-91ea-408b-a8fd-5105f3c4c626">
+
+## Out of scope for launch (amongst other things)
+
+- Sidebar (Index view)
+- Canvas-powered dashboards
+- Query builder
+- [Check this mega issue for details + the full list](https://github.com/PostHog/posthog/issues/18089)
+
+## Rollout plan
+
+- [x]  Now: Roll out [Notebooks](https://app.posthog.com/feature_flags/8734) to PostHog Team
+- [ ]  Now: Roll out [PostHog 3000 (Base 3000 scope)](https://app.posthog.com/feature_flags/8472) to PostHog Team
+- [ ]  October 30th: Roll out Notebooks Beta to 100% of users, to get some early feedback
+- [ ]  October 30th: [Notebooks Beta Marketing Activities](https://github.com/PostHog/meta/issues/139)
+- [ ]  November 13th: Roll out Notebooks to 100% of users
+- [ ]  November 13th: Roll out PostHog 3000 (Base 3000 scope) to 100% of users
+- [ ]  November 13th onwards: Notebooks & Base 3000 Marketing activities
+
+## To Dos for launch
+
+- [ ]  Finish [sprint goals](https://github.com/PostHog/posthog/issues/18174#issuecomment-1779475963): Ben, David, Michael, Thomas
+- [ ]  [Notebooks Beta](https://github.com/PostHog/meta/issues/139) Marketing: Joe to lead (separate issue)
+- [ ]  [Notebooks](https://github.com/PostHog/meta/issues/139) & Base 3000 Marketing: Joe to lead (separate issue)
+- [ ]  Test Base 3000 and Notebooks and report any bugs in the [#posthog3000](https://posthog.slack.com/archives/C04L2CV12V9) or [#notebooks-feedback](https://posthog.slack.com/archives/C05N9R3HT7V) Slack channesl: Everyone

--- a/requests-for-comments/2023-10-27-base3000-launch.md
+++ b/requests-for-comments/2023-10-27-base3000-launch.md
@@ -17,14 +17,13 @@ We want to launch the ‘first version’ of PostHog 3000 after the next sprint,
 - [Check this mega issue for details + the full list](https://github.com/PostHog/posthog/issues/18089)
 
 ## Rollout plan
+- [ ] Base 3000 ready to release (10th Nov)
+- [ ] Internal testing starts (10th Nov)
+- [ ] Docs revamp and updates ready (24th Nov)
+- [ ] Product pages for 3000 / Notebooks (24th Nov)
+- [ ] Release [PostHog 3000 (Base 3000 scope)](https://app.posthog.com/feature_flags/8472) (27th Nov)
+- [ ] Release [Notebooks](https://app.posthog.com/feature_flags/8734) (4th Dec) (or together with Base 3000 if we feel docs are easier)
 
-- [x]  Now: Roll out [Notebooks](https://app.posthog.com/feature_flags/8734) to PostHog Team
-- [ ]  Now: Roll out [PostHog 3000 (Base 3000 scope)](https://app.posthog.com/feature_flags/8472) to PostHog Team
-- [ ]  October 30th: Roll out Notebooks Beta to 100% of users, to get some early feedback
-- [ ]  October 30th: [Notebooks Beta Marketing Activities](https://github.com/PostHog/meta/issues/139)
-- [ ]  November 13th: Roll out Notebooks to 100% of users
-- [ ]  November 13th: Roll out PostHog 3000 (Base 3000 scope) to 100% of users
-- [ ]  November 13th onwards: Notebooks & Base 3000 Marketing activities
 
 ## To Dos for launch
 

--- a/requests-for-comments/2023-10-27-base3000-launch.md
+++ b/requests-for-comments/2023-10-27-base3000-launch.md
@@ -1,11 +1,12 @@
 # Base 3000 & Notebooks launch
 
-We want to launch the ‘first version’ of PostHog 3000 after the next sprint, which means the week starting November 13th (+ 1 week if needed). We have decided to **include Notebooks** in this launch, so that we can have a big launch that combines functionality and design changes.
+We want to launch the ‘first version’ of PostHog 3000 after the next sprint, which means the week starting November 13th (+ 1 week if needed). We have decided to **include Notebooks** in this launch, so that we can have a more impactful launch that combines functionality and design changes.
 
 ## Scope for launch
 
 - Dark Mode
 - Base 3000 [Check this mega issue for details](https://github.com/PostHog/posthog/issues/18089)
+- Notebooks side panel
     
 <img width="674" alt="Screenshot 2023-10-27 at 10 38 50" src="https://github.com/PostHog/meta/assets/14750837/abb9e559-91ea-408b-a8fd-5105f3c4c626">
 
@@ -15,8 +16,6 @@ We want to launch the ‘first version’ of PostHog 3000 after the next sprint,
 - Canvas-powered dashboards
 - Query builder
 - [Check this mega issue for details + the full list](https://github.com/PostHog/posthog/issues/18089)
-
-
 
 
 ## Rollout plan

--- a/requests-for-comments/2023-10-27-base3000-launch.md
+++ b/requests-for-comments/2023-10-27-base3000-launch.md
@@ -67,4 +67,6 @@ This might be hard to do or to get clear signals for whether it is an improvemen
 - [ ]  Finish [sprint goals](https://github.com/PostHog/posthog/issues/18174#issuecomment-1779475963): Ben, David, Michael, Thomas
 - [ ]  [Notebooks Beta](https://github.com/PostHog/meta/issues/139) Marketing: Joe to lead (separate issue)
 - [ ]  [Notebooks](https://github.com/PostHog/meta/issues/139) & Base 3000 Marketing: Joe to lead (separate issue)
-- [ ]  Test Base 3000 and Notebooks and report any bugs in the [#posthog3000](https://posthog.slack.com/archives/C04L2CV12V9) or [#notebooks-feedback](https://posthog.slack.com/archives/C05N9R3HT7V) Slack channesl: Everyone
+- [ ]  Test Base 3000 and Notebooks and report any bugs in the [#posthog3000](https://posthog.slack.com/archives/C04L2CV12V9) or [#notebooks-feedback](https://posthog.slack.com/archives/C05N9R3HT7V) Slack channels: Everyone
+- [ ] Make sure signup/login aren't impacted by 3000 styles (until we are ready to test them)
+- [ ] Get new onboarding rolled out to everyone and 3000-ize it @raquelmsmith 

--- a/requests-for-comments/2023-10-27-base3000-launch.md
+++ b/requests-for-comments/2023-10-27-base3000-launch.md
@@ -16,13 +16,51 @@ We want to launch the ‘first version’ of PostHog 3000 after the next sprint,
 - Query builder
 - [Check this mega issue for details + the full list](https://github.com/PostHog/posthog/issues/18089)
 
+
+
+
 ## Rollout plan
 - [ ] Base 3000 ready to release (10th Nov)
-- [ ] Internal testing starts (10th Nov)
+- [ ] Internal and a/b testing starts (13th Nov)
 - [ ] Docs revamp and updates ready (24th Nov)
 - [ ] Product pages for 3000 / Notebooks (24th Nov)
 - [ ] Release [PostHog 3000 (Base 3000 scope)](https://app.posthog.com/feature_flags/8472) (27th Nov)
 - [ ] Release [Notebooks](https://app.posthog.com/feature_flags/8734) (4th Dec) (or together with Base 3000 if we feel docs are easier)
+
+
+## Pre-launch evaluation
+
+We decided that even the "base" version has enough major changes that we want to test that it both doesn't impact our key metrics negatively as well as (if possible) evaluate if it is overall an improvement, especially with new users.
+This might be hard to do or to get clear signals for whether it is an improvement (especially as it is only a step along the way to the end goal UI/UX).
+
+- [ ] **Signup/onboarding Experiment**: _just_ for the onboarding we could experiment with the styles separate from the rest of the app
+  - [ ] **Metrics**: Same as usual onboarding metrics?
+  - [ ] Important that we keep the style consistent from signup through to app usage as otherwise it will be a janky experience
+  - [ ] We mostly care about **negatively** impacting the flow
+- [ ] **General Experiment**: in combination with internal testing we could start to roll out the product to new and existing users as an experiment
+  - [ ] Important that we keep the style consistent from signup through to app usage as otherwise it will be a janky experience
+  - [ ] We originally opted against being able to go back to the old UI - do we want to offer this?
+  - [ ] **Metrics**:
+    - [ ] Same as onboarding?
+    - [ ] Retention over time (what time frame do we need to be clear on this?)
+    - [ ] Number of clicks on the sidebar as a negative metric?
+    - [ ] Number of searches now vs before?
+    - [ ] Choice to use dark mode?
+- [ ] **Qualatitive testing**
+  - [ ] Survey for opted in users witht the new UI to ask what they think about it?
+  - [ ] In person feedback
+
+### How a decision will be made
+
+**Negative key metrics** 
+- Investigate why and follow up 
+
+**Same or positive key metrics** 
+- Still investigate why (we don't want to be overly confident based on metrics alone) but move forward with rollout
+
+**User feedback**
+- Differentiate between taste and functionality.
+  - If people are actively havign a hard time to work with the UI / find what they want (especially new users) this is the kind of thing we should act on
 
 
 ## To Dos for launch

--- a/requests-for-comments/2023-10-27-base3000-launch.md
+++ b/requests-for-comments/2023-10-27-base3000-launch.md
@@ -45,8 +45,8 @@ This might be hard to do or to get clear signals for whether it is an improvemen
     - [ ] Number of clicks on the sidebar as a negative metric?
     - [ ] Number of searches now vs before?
     - [ ] Choice to use dark mode?
-- [ ] **Qualatitive testing**
-  - [ ] Survey for opted in users witht the new UI to ask what they think about it?
+- [ ] **Qualitative testing**
+  - [ ] Survey for opted in users with the new UI to ask what they think about it?
   - [ ] In person feedback
 
 ### How a decision will be made


### PR DESCRIPTION
We are planning to launch the first version of PostHog 3000 ("Base 3000") and Notebooks together after the next sprint (~13th November). Please check this RFC for details, timeline and to dos.