### PR TITLE
Onboarding Emails 4.0

### DIFF
--- a/requests-for-comments/2023-10-31-onboarding-emails.md
+++ b/requests-for-comments/2023-10-31-onboarding-emails.md
@@ -13,72 +13,11 @@ The onboarding email flow is managed by the marketing team, and is implemented w
 ## Onboarding for US and EU PostHog Cloud
 **Campaign in Customer.io:** Onboarding - All cloud users 
 
+[See image](/images/customerio-workflow-onboarding-4.0---all-cloud-users.png).
+
 The 'full' onboarding experience is delivered across some 'sub' campaigns, below, which trigger based on user properties. This is because we don't want to email users about how to use a feature until we've checked and taken action on whether they are subscribed to other tools.
 
 This campaign triggers when a user completes the `user signed up` event for the first time, on either PostHog US or PostHog EU, provided they also have a valid email address.
-
-1. Wait one hour.
-2. Send new Welcome Email. 
-3. Check users' role in organization, using the `role_at_organization` property.
-    1. If `founder` then wait 12 hours, and send Joe's Newsletter Invite email.
-        1. Check if user clicked the subscription CTA.
-            1. If `Yes`, add `newsletter_cta_clicked: true` to user.
-            2. If `No`, do nothing. 
-        2. Wait 12 hours
-    2. If `engineering` then wait 12 hours, and send Andy's Newsletter Invite email. 
-        1. Check if user clicked the subscription CTA.
-            1. If `Yes`, add `newsletter_cta_clicked: true` to user.
-            2. If `No`, do nothing. 
-        2. Wait 12 hours
-    3. If `product` then wait 12 hours. 
-        1. Check if the user has performed `action created`
-            1. If `Yes`, send NEW email promoting the user interview survey template
-            2. If `No`, send Advice for Product Teams email.
-        3. Wait 12 hours.
-    4. If `marketing` then wait 12 hours. 
-        1. Check if the user has performed `action created`
-            1. If `Yes`, send NEW email promoting the dashboard templates. 
-            2. If `No`, send Advice for Marketing Teams email.
-        3. Wait 12 hours.
-    5. If `sales` then wait 12 hours. 
-        1. Check if the user has performed `action created`
-            1. If `Yes`, send NEW email promoting the tutorials section.
-            2. If `No`, send Advice for Sales Teams email.
-        3. Wait 12 hours.
-    6. If not `founder` `engineering` `product` `marketing` or `sales` then wait 24 hours
-4. Wait 1 week.
-5. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-6. Check if the user is in the `Subscribers to Product Analytics` segment
-    1. If `No`, send Analytics Upsell
-    2. If `Yes`, check if the user is in the `Subscribers to Session Replays` segment
-        1. If `No`, send Replay Upsell email
-        2. If `Yes`, check if the user is in the `Subscribers to Feature Flags` segment
-            1. If `No`, send Feature Flags Upsell email.
-            2. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
-                1. If `No`, send Surveys Upsell email
-                2. If `Yes`, send email about enabling beta features
-7. Wait 1 week. 
-8. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-9. Check if the user is in the `Subscribers to Session Replays` segment
-    1. If `No`, send Replay Upsell email
-    2. If `Yes`, check if the user is in the `Subscribers to Feature Flags` segment
-        1. If `No`, send Feature Flags Upsell email.
-        2. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
-            1. If `No`, send Surveys Upsell email
-            2. If `Yes`, send email inviting user to join the PostHog community
-10. Wait 1 week. 
-11. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-12. Check if the user is in the `Subscribers to Feature Flags` segment
-    1. If `No`, send Feature Flags Upsell email.
-    2. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
-        1. If `No`, send Surveys Upsell email
-        2. If `Yes`, send email email about dashboard and survey templates 
-13. Wait 1 week. 
-14. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-15. Check if the user is in the `Subscribers to Surveys` segment
-    1. If `Yes`, send an email pushing about building like PostHog
-    2. If `No`, send Survey Upsell email
-16. Add `completed_onboarding_emails: true` to user 
 
 ### Product analytics onboarding flow
 **Campaign in Customer.io:** Product Analytics onboarding

--- a/requests-for-comments/2023-10-31-onboarding-emails.md
+++ b/requests-for-comments/2023-10-31-onboarding-emails.md
@@ -46,11 +46,9 @@ This campaign triggers when a user completes the `user signed up` event for the 
             2. If `No`, send Advice for Sales Teams email.
         3. Wait 12 hours.
     6. If not `founder` `engineering` `product` `marketing` or `sales` then wait 24 hours
-4. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-5. Send AARRR intro article email
-6. Wait 1 week.
-7. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-8. Check if the user is in the `Subscribers to Product Analytics` segment
+4. Wait 1 week.
+5. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
+6. Check if the user is in the `Subscribers to Product Analytics` segment
     1. If `No`, send Analytics Upsell
     2. If `Yes`, check if the user is in the `Subscribers to Session Replays` segment
         1. If `No`, send Replay Upsell email
@@ -59,28 +57,28 @@ This campaign triggers when a user completes the `user signed up` event for the 
             2. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
                 1. If `No`, send Surveys Upsell email
                 2. If `Yes`, send email about enabling beta features
-9. Wait 1 week. 
-10. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-11. Check if the user is in the `Subscribers to Session Replays` segment
+7. Wait 1 week. 
+8. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
+9. Check if the user is in the `Subscribers to Session Replays` segment
     1. If `No`, send Replay Upsell email
     2. If `Yes`, check if the user is in the `Subscribers to Feature Flags` segment
         1. If `No`, send Feature Flags Upsell email.
         2. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
             1. If `No`, send Surveys Upsell email
             2. If `Yes`, send email inviting user to join the PostHog community
-12. Wait 1 week. 
-13. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-14. Check if the user is in the `Subscribers to Feature Flags` segment
+10. Wait 1 week. 
+11. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
+12. Check if the user is in the `Subscribers to Feature Flags` segment
     1. If `No`, send Feature Flags Upsell email.
     2. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
         1. If `No`, send Surveys Upsell email
         2. If `Yes`, send email email about dashboard and survey templates 
-15. Wait 1 week. 
-16. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-17. Check if the user is in the `Subscribers to Surveys` segment
+13. Wait 1 week. 
+14. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
+15. Check if the user is in the `Subscribers to Surveys` segment
     1. If `Yes`, send an email pushing about building like PostHog
     2. If `No`, send Survey Upsell email
-18. Add `completed_onboarding_emails: true` to user 
+16. Add `completed_onboarding_emails: true` to user 
 
 ### Product analytics onboarding flow
 **Campaign in Customer.io:** Product Analytics onboarding

--- a/requests-for-comments/2023-10-31-onboarding-emails.md
+++ b/requests-for-comments/2023-10-31-onboarding-emails.md
@@ -18,7 +18,7 @@ The 'full' onboarding experience is delivered across some 'sub' campaigns, below
 This campaign triggers when a user completes the `user signed up` event for the first time, on either PostHog US or PostHog EU, provided they also have a valid email address.
 
 1. Wait one hour.
-2. Send Welcome Email. 
+2. Send new Welcome Email. 
 3. Check users' role in organization, using the `role_at_organization` property.
     1. If `founder` then wait 12 hours, and send Joe's Newsletter Invite email.
         1. Check if user clicked the subscription CTA.

--- a/requests-for-comments/2023-10-31-onboarding-emails.md
+++ b/requests-for-comments/2023-10-31-onboarding-emails.md
@@ -50,26 +50,46 @@ This campaign triggers when a user completes the `user signed up` event for the 
 5. Send AARRR intro article email
 6. Wait 1 week.
 7. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-8. Check if the user is in the `Subscribers to Session Replays` segment
-    1. If `Yes`, check if the user is in the `Subscribers to Feature Flags` segment
-        1. If `Yes`, if the user is in the `Subscribers to Surveys` segment
-            1. If `Yes`, send [New email about using templates]
-            2. If `No`, send Survey Upsell email.
-        2. If `No`, send Feature Flag Upsell email
-    2. If `No`, send Replay Upsell email. 
+8. Check if the user is in the `Subscribers to Product Analytics` segment
+    1. If `No`, send Analytics Upsell email
+    2. If `Yes`, check if the user is in the `Subscribers to Session Replays` segment
+        1. If `No`, send Replay Upsell email
+        2. If `Yes`, check if the user is in the `Subscribers to Feature Flags` segment
+            1. If `No`, send Feature Flags Upsell email.
+            2. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
+                1. If `No`, send Surveys Upsell email
+                2. If `Yes`, send email about enabling beta features
 9. Wait 1 week. 
 10. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-11. Check if the user is in the `Subscribers to Feature Flags` segment
-    1. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
-        1. If `Yes`, [send new email about Toolbar]
-        2. If `No`, send Surveys Upsell email
-    2. If `No`, send Feature Flag Upsell email
+11. Check if the user is in the `Subscribers to Session Replays` segment
+    1. If `No`, send Replay Upsell email
+    2. If `Yes`, check if the user is in the `Subscribers to Feature Flags` segment
+        1. If `No`, send Feature Flags Upsell email.
+        2. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
+            1. If `No`, send Surveys Upsell email
+            2. If `Yes`, send email inviting user to join the PostHog community
 12. Wait 1 week. 
 13. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
-14. Check if the user is in the `Subscribers to Surveys` segment
-    1. If `Yes`, [send new email about notebooks]
+14. Check if the user is in the `Subscribers to Feature Flags` segment
+    1. If `No`, send Feature Flags Upsell email.
+    2. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
+        1. If `No`, send Surveys Upsell email
+        2. If `Yes`, send email email about dashboard and survey templates 
+15. Wait 1 week. 
+16. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
+17. Check if the user is in the `Subscribers to Surveys` segment
+    1. If `Yes`, send an email pushing about building like PostHog
     2. If `No`, send Survey Upsell email
-15. Add `completed_onboarding_emails: true` to user. 
+18. Add `completed_onboarding_emails: true` to user 
+
+### Product analytics onboarding flow
+**Campaign in Customer.io:** Product Analytics onboarding
+
+This campaign triggers when a user enters the `Subscribers to Session Replays` segment, provided they also have a valid email address. 
+
+1. Wait 1 day, and until a weekday between 9AM and 12PM in the users' time zone (UTC fallback)
+2. Product Analytics Onboarding email
+3. Add `productanalytics_onboarding_complete: true` to user. 
 
 ### Session replay onboarding flow
 **Campaign in Customer.io:** Session replay onboarding

--- a/requests-for-comments/2023-10-31-onboarding-emails.md
+++ b/requests-for-comments/2023-10-31-onboarding-emails.md
@@ -51,7 +51,7 @@ This campaign triggers when a user completes the `user signed up` event for the 
 6. Wait 1 week.
 7. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
 8. Check if the user is in the `Subscribers to Product Analytics` segment
-    1. If `No`, send Analytics Upsell email
+    1. If `No`, send Analytics Upsell
     2. If `Yes`, check if the user is in the `Subscribers to Session Replays` segment
         1. If `No`, send Replay Upsell email
         2. If `Yes`, check if the user is in the `Subscribers to Feature Flags` segment
@@ -85,10 +85,12 @@ This campaign triggers when a user completes the `user signed up` event for the 
 ### Product analytics onboarding flow
 **Campaign in Customer.io:** Product Analytics onboarding
 
-This campaign triggers when a user enters the `Subscribers to Session Replays` segment, provided they also have a valid email address. 
+This campaign triggers when a user enters the `Subscribers to Product Analytics` segment, provided they also have a valid email address. 
 
 1. Wait 1 day, and until a weekday between 9AM and 12PM in the users' time zone (UTC fallback)
-2. Product Analytics Onboarding email
+2. Check if user is in the `Subscribers to Group Analytics` segment
+    1. If `Yes`, send Product Onboarding Email
+    2. If `No`, send Product Onboarding + Groups Upsell email
 3. Add `productanalytics_onboarding_complete: true` to user. 
 
 ### Session replay onboarding flow

--- a/requests-for-comments/2023-10-31-onboarding-emails.md
+++ b/requests-for-comments/2023-10-31-onboarding-emails.md
@@ -28,7 +28,7 @@ This campaign triggers when a user completes the `user signed up` event for the 
     2. If `engineering` then wait 12 hours, and send Andy's Newsletter Invite email. 
         1. Check if user clicked the subscription CTA.
             1. If `Yes`, add `newsletter_cta_clicked: true` to user.
-            2. If n`No`o, do nothing. 
+            2. If `No`, do nothing. 
         2. Wait 12 hours
     3. If `product` then wait 12 hours. 
         1. Check if the user has performed `action created`

--- a/requests-for-comments/2023-10-31-onboarding-emails.md
+++ b/requests-for-comments/2023-10-31-onboarding-emails.md
@@ -22,28 +22,28 @@ This campaign triggers when a user completes the `user signed up` event for the 
 3. Check users' role in organization, using the `role_at_organization` property.
     1. If `founder` then wait 12 hours, and send Joe's Newsletter Invite email.
         1. Check if user clicked the subscription CTA.
-            1. If yes, add `newsletter_cta_clicked: true` to user.
-            2. If no, do nothing. 
+            1. If `Yes`, add `newsletter_cta_clicked: true` to user.
+            2. If `No`, do nothing. 
         2. Wait 12 hours
     2. If `engineering` then wait 12 hours, and send Andy's Newsletter Invite email. 
         1. Check if user clicked the subscription CTA.
-            1. If yes, add `newsletter_cta_clicked: true` to user.
-            2. If no, do nothing. 
+            1. If `Yes`, add `newsletter_cta_clicked: true` to user.
+            2. If n`No`o, do nothing. 
         2. Wait 12 hours
     3. If `product` then wait 12 hours. 
         1. Check if the user has performed `action created`
-            1. If yes, do nothing.
-            2. If no, send Advice for Product Teams email.
+            1. If `Yes`, do nothing.
+            2. If `No`, send Advice for Product Teams email.
         3. Wait 12 hours.
     4. If `marketing` then wait 12 hours. 
         1. Check if the user has performed `action created`
-            1. If yes, do nothing.
-            2. If no, send Advice for Marketing Teams email.
+            1. If `Yes`, do nothing.
+            2. If `No`, send Advice for Marketing Teams email.
         3. Wait 12 hours.
     5. If `sales` then wait 12 hours. 
         1. Check if the user has performed `action created`
-            1. If yes, do nothing.
-            2. If no, send Advice for Sales Teams email.
+            1. If `Yes`, do nothing.
+            2. If `No`, send Advice for Sales Teams email.
         3. Wait 12 hours.
     6. If not `founder` `engineering` `product` `marketing` or `sales` then wait 24 hours
 4. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
@@ -51,21 +51,23 @@ This campaign triggers when a user completes the `user signed up` event for the 
 6. Wait 1 week.
 7. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
 8. Check if the user is in the `Subscribers to Session Replays` segment
-    1. If `Yes`, do nothing. (See Session replay onboarding flow)
-    2. If `No`, assign to a random cohort branch.
-        1. 50% receive Session replay upsell email
-        2. 50% recieve Experiment: Personal Invite email
-9. Wait 1 week.
+    1. If `Yes`, check if the user is in the `Subscribers to Feature Flags` segment
+        1. If `Yes`, if the user is in the `Subscribers to Surveys` segment
+            1. If `Yes`, send [New email about using templates]
+            2. If `No`, send Survey Upsell email.
+        2. If `No`, send Feature Flag Upsell email
+    2. If `No`, send Replay Upsell email. 
+9. Wait 1 week. 
 10. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
 11. Check if the user is in the `Subscribers to Feature Flags` segment
-    1. If `Yes`, do nothing. (See Feature flag onboarding flow)
-    2. If `No`, assign to random cohort branch. 
-        1. 50% receive Feature Flag Upsell email 1
-        2. 50% recieve Feature Flag Upsell email 2
-12. Wait 5 days. 
+    1. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
+        1. If `Yes`, [send new email about hogQL]
+        2. If `No`, send Surveys Upsell email
+    2. If `No`, send Feature Flag Upsell email
+12. Wait 1 week. 
 13. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
 14. Check if the user is in the `Subscribers to Surveys` segment
-    1. If `Yes`, do nothing. (See Survey onboarding flow)
+    1. If `Yes`, [send new email about notebooks]
     2. If `No`, send Survey Upsell email
 15. Add `completed_onboarding_emails: true` to user. 
 
@@ -74,30 +76,27 @@ This campaign triggers when a user completes the `user signed up` event for the 
 
 This campaign triggers when a user enters the `Subscribers to Session Replays` segment, provided they also have a valid email address. 
 
-1. Wait until `completed_onboarding_emails: true` for user. 
-2. Wait 1 day, and until a weekday between 9AM and 12PM in the users' time zone (UTC fallback)
-3. Send Replay Onboarding email
-4. Add `replay_onboarding_complete: true` to user. 
+1. Wait 1 day, and until a weekday between 9AM and 12PM in the users' time zone (UTC fallback)
+2. Send Replay Onboarding email
+3. Add `replay_onboarding_complete: true` to user. 
 
 ### Feature flag onboarding flow
 **Campaign in Customer.io:** Feature flag onboarding
 
 This campaign triggers when a user enters the `Subscribers to Feature Flags` segment, provided they also have a valid email address. 
 
-1. Wait until `completed_onboarding_emails: true` for user. 
-2. Wait 1 day, and until a weekday between 12PM and 3PM in the users' time zone (UTC fallback)
-3. Send Welcome to Flags email
-4. Add `flag_onboarding_complete: true` to user.
+1. Wait 1 day, and until a weekday between 12PM and 3PM in the users' time zone (UTC fallback)
+2. Send Welcome to Flags email
+3. Add `flag_onboarding_complete: true` to user.
 
 ### Survey onboarding flow
 **Campaign in Customer.io:** Surveys onboarding
 
 This campaign triggers when a user enters the `Subscribers to Surveys` segment, provided they also have a valid email address. 
 
-1. Wait until `completed_onboarding_emails: true` for user. 
-2. Wait 1 day, and until a weekday between 3PM and 5PM in the users' time zone (UTC fallback)
-3. Send Welcome to Surveys email
-4. Add `surveys_onboarding_complete: true` to user.
+1. Wait 1 day, and until a weekday between 3PM and 5PM in the users' time zone (UTC fallback)
+2. Send Welcome to Surveys email
+3. Add `surveys_onboarding_complete: true` to user.
 
 ## G2 Review Request Flow
 **Campaign in Customer.io:** G2 Review Requester

--- a/requests-for-comments/2023-10-31-onboarding-emails.md
+++ b/requests-for-comments/2023-10-31-onboarding-emails.md
@@ -61,7 +61,7 @@ This campaign triggers when a user completes the `user signed up` event for the 
 10. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
 11. Check if the user is in the `Subscribers to Feature Flags` segment
     1. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
-        1. If `Yes`, [send new email about HogQL]
+        1. If `Yes`, [send new email about Toolbar]
         2. If `No`, send Surveys Upsell email
     2. If `No`, send Feature Flag Upsell email
 12. Wait 1 week. 

--- a/requests-for-comments/2023-10-31-onboarding-emails.md
+++ b/requests-for-comments/2023-10-31-onboarding-emails.md
@@ -32,17 +32,17 @@ This campaign triggers when a user completes the `user signed up` event for the 
         2. Wait 12 hours
     3. If `product` then wait 12 hours. 
         1. Check if the user has performed `action created`
-            1. If `Yes`, do nothing.
+            1. If `Yes`, send NEW email promoting the user interview survey template
             2. If `No`, send Advice for Product Teams email.
         3. Wait 12 hours.
     4. If `marketing` then wait 12 hours. 
         1. Check if the user has performed `action created`
-            1. If `Yes`, do nothing.
+            1. If `Yes`, send NEW email promoting the dashboard templates. 
             2. If `No`, send Advice for Marketing Teams email.
         3. Wait 12 hours.
     5. If `sales` then wait 12 hours. 
         1. Check if the user has performed `action created`
-            1. If `Yes`, do nothing.
+            1. If `Yes`, send NEW email promoting the tutorials section.
             2. If `No`, send Advice for Sales Teams email.
         3. Wait 12 hours.
     6. If not `founder` `engineering` `product` `marketing` or `sales` then wait 24 hours

--- a/requests-for-comments/2023-10-31-onboarding-emails.md
+++ b/requests-for-comments/2023-10-31-onboarding-emails.md
@@ -61,7 +61,7 @@ This campaign triggers when a user completes the `user signed up` event for the 
 10. Wait until a weekday between 1PM and 5PM in the users' time zone (UTC fallback)
 11. Check if the user is in the `Subscribers to Feature Flags` segment
     1. If `Yes`, check if the user is in the `Subscribers to Surveys` segment
-        1. If `Yes`, [send new email about hogQL]
+        1. If `Yes`, [send new email about HogQL]
         2. If `No`, send Surveys Upsell email
     2. If `No`, send Feature Flag Upsell email
 12. Wait 1 week. 


### PR DESCRIPTION
It's the biggest thing to happen to onboarding emails since 3.9. 

These suggested changes would alter the way in which we check for elligibility for upselling users, and introduce three new back-up emails as fallbacks.

Changes:

- users now receive 1x email each week for each of the first three weeks. 
- added four new fallback emails as if a user is already subscribed to all features, focusing on Betas, Community, Templates, Content
- prepped a notebooks upsell for when that launches
- merged AARRR email inside the welcome email
- added have four new early-stage fall backs within the role flow at the start
- bias towards upsell emails, over other types of comm
- bias towards upselling Analytics, Session Replay, then Flags, then Surveys - in that order.
- add have an onboarding flow for Analytics which includes an upsell cycle for Group Analytics. 
- reconciled the existing experiments to use the most successful variant. 
- no longer check if a user completes onboarding to send the per-feature emails when someone subscribes to a product. 
- add properties to track onboarding goals at a higher level than before

I've drafted all new content and appended as comments

Feedback on all points - including the underlying logic - greatly appreciated. 