### PR TITLE
Customer reach out email for breaking change to feature flags

### DIFF
--- a/requests-for-comments/2025-09-09-ff-eval-fix.md
+++ b/requests-for-comments/2025-09-09-ff-eval-fix.md
@@ -34,7 +34,7 @@ However, please review your affected feature flags if:
 3. Your analytics or A/B tests depend on specific variant distributions
 
 ## Fix Release Timeline
-- **PostHog Servers**: Fix deployment [2025-09-15]
+- **PostHog Servers**: Fix deployment [2025-09-12]
 - **Server SDKs if you are using [local-evaluation](https://posthog.com/docs/feature-flags/local-evaluation) (Python, Go, Node, PHP, Ruby, .NET)**: Please check the changelog for the specific version and release date
 
 ## Questions or Concerns?

--- a/requests-for-comments/2025-09-09-ff-eval-fix.md
+++ b/requests-for-comments/2025-09-09-ff-eval-fix.md
@@ -31,7 +31,6 @@ Previously, Condition 2 would incorrectly be evaluated first. Now conditions are
 However, please review your affected feature flags if:
 1. You noticed unexpected variant assignments in the past and worked around them
 2. You have complex flags with multiple conditions mixing variant overrides
-3. Your analytics or A/B tests depend on specific variant distributions
 
 ## Fix Release Timeline
 - **PostHog Servers**: Fix deployment [2025-09-12]

--- a/requests-for-comments/2025-09-09-ff-eval-fix.md
+++ b/requests-for-comments/2025-09-09-ff-eval-fix.md
@@ -1,0 +1,44 @@
+### Customer reach out email
+
+Subject: Feature Flag Evaluation Order Fix - Action May Be Required
+
+Hello,
+
+We're writing to inform you about an important fix we're deploying to our feature flag evaluation system that will affect your current flag configurations.
+
+## What Changed
+
+We discovered and fixed a bug in how feature flags evaluate conditions when variant overrides are present. Previously, conditions with variant overrides were incorrectly being evaluated before conditions without variant overrides, regardless of their defined order. This has now been corrected to respect the order you define in your flag configuration.
+
+## Who Is Affected
+
+We have identified that at least one of your active flags will be affected. To identify potentially affected flags, look for multi-variant flags where:
+- Earlier conditions have no variant override (rely on default multivariate distribution)
+- Later conditions have explicit variant overrides
+- The order of these conditions matters for your use case
+
+Example of an affected configuration:
+Condition 1: If country = "United States" → (no variant override, uses default
+distribution)
+Condition 2: Everyone else → variant = "test"
+
+Previously, Condition 2 would incorrectly be evaluated first. Now conditions are evaluated in the order you defined them (1, then 2).
+
+## What You Need To Do
+
+**Most customers require no action.** The fix ensures flags work as originally intended.
+
+However, please review your affected feature flags if:
+1. You noticed unexpected variant assignments in the past and worked around them
+2. You have complex flags with multiple conditions mixing variant overrides
+3. Your analytics or A/B tests depend on specific variant distributions
+
+## Fix Release Timeline
+- **PostHog Servers**: Fix deployment [2025-09-15]
+- **Server SDKs if you are using [local-evaluation](https://posthog.com/docs/feature-flags/local-evaluation) (Python, Go, Node, PHP, Ruby, .NET)**: Please check the changelog for the specific version and release date
+
+## Questions or Concerns?
+
+If you have any questions or need assistance reviewing your feature flags, please don't hesitate to reach out to our support team.
+
+We apologize for any confusion this may have caused and appreciate your understanding as we continue to improve PostHog.


### PR DESCRIPTION
Email draft to inform customers of a breaking change coming to feature flag evaluation. I intend to send this email to specific team ids affected. 

US: https://metabase.prod-us.posthog.dev/question/1585-list-of-team-ids-affected (~250)
EU: https://metabase.prod-eu.posthog.dev/question/512-affected-team-ids-in-eu (~100)

https://github.com/PostHog/posthog/issues/37854